### PR TITLE
Lowered the maximum connection test size to comply with API limits

### DIFF
--- a/resources/lib/server_detect.py
+++ b/resources/lib/server_detect.py
@@ -28,7 +28,7 @@ __addon_name__ = __addon__.getAddonInfo('name')
 
 def check_connection_speed():
     log.debug("check_connection_speed")
-    import web_pdb; web_pdb.set_trace()
+
     settings = xbmcaddon.Addon()
     verify_cert = settings.getSetting('verify_cert') == 'true'
     http_timeout = int(settings.getSetting("http_timeout"))

--- a/resources/lib/server_detect.py
+++ b/resources/lib/server_detect.py
@@ -28,7 +28,7 @@ __addon_name__ = __addon__.getAddonInfo('name')
 
 def check_connection_speed():
     log.debug("check_connection_speed")
-
+    import web_pdb; web_pdb.set_trace()
     settings = xbmcaddon.Addon()
     verify_cert = settings.getSetting('verify_cert') == 'true'
     http_timeout = int(settings.getSetting("http_timeout"))
@@ -70,7 +70,7 @@ def check_connection_speed():
     head = du.get_auth_header(True)
     head["User-Agent"] = "JellyCon-" + ClientInformation().get_version()
 
-    conn.request(method="GET", url=url_path, headers=head)
+    conn.request(method="GET", url=url, headers=head)
 
     progress_dialog = xbmcgui.DialogProgress()
     message = 'Testing with {0} MB of data'.format(speed_test_data_size)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -133,7 +133,7 @@
 		<setting id="use_cached_widget_data" type="bool" label="30441" default="false" visible="true" enable="true" />
 		<setting id="showLoadProgress" type="bool" label="30120" default="false" visible="true" enable="true" />
 		<setting id="suppressErrors" type="bool" label="30315" default="false" visible="true" enable="true" />
-		<setting id="speed_test_data_size" type="slider" label="30436" default="15" range="5,1,100" option="int" visible="true"/>
+		<setting id="speed_test_data_size" type="slider" label="30436" default="10" range="1,1,10" option="int" visible="true"/>
 
 	</category>
 	<category label="30421">


### PR DESCRIPTION
Emby let you request more data than the Jellyfin API does. Brought the allowed options back in line with what our API allows. Fixes #5 