### PR TITLE
Store full URL instead of component parts. Fixes #1 and Fixes #2

### DIFF
--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -342,50 +342,15 @@ class DownloadUtils:
 
     def get_server(self):
         settings = xbmcaddon.Addon()
-        host = settings.getSetting('ipaddress')
 
-        if len(host) == 0 or host == "<none>":
-            return None
+        #For migration from storing URL parts to just one URL
+        if settings.getSetting('ipaddress') != "" and settings.getSetting('ipaddress') != "&lt;none&gt;":
+            log.info("Migrating to new server url storage")
+            url = ("http://" if settings.getSetting('protocol') == "0" else "https://") + settings.getSetting('ipaddress') + ":" + settings.getSetting('port')
+            settings.setSetting('server_address', url)
+            settings.setSetting('ipaddress', "")
 
-        port = settings.getSetting('port')
-
-        if not port and self.use_https:
-            port = "443"
-            settings.setSetting("port", port)
-        elif not port:
-            port = "80"
-            settings.setSetting("port", port)
-
-        # if user entered a full path i.e. http://some_host:port
-        if host.lower().strip().startswith("http://") or host.lower().strip().startswith("https://"):
-            log.debug("Extracting host info from url: {0}", host)
-            url_bits = urlparse(host.strip())
-
-            if host.lower().strip().startswith("http://"):
-                settings.setSetting('protocol', '0')
-                self.use_https = False
-            elif host.lower().strip().startswith("https://"):
-                settings.setSetting('protocol', '1')
-                self.use_https = True
-
-            if url_bits.hostname is not None and len(url_bits.hostname) > 0:
-                host = url_bits.hostname
-
-                if url_bits.username and url_bits.password:
-                    host = "%s:%s@" % (url_bits.username, url_bits.password) + host
-
-                settings.setSetting("ipaddress", host)
-
-            if url_bits.port is not None and url_bits.port > 0:
-                port = str(url_bits.port)
-                settings.setSetting("port", port)
-
-        if self.use_https:
-            server = "https://" + host + ":" + port
-        else:
-            server = "http://" + host + ":" + port
-
-        return server
+        return settings.getSetting('server_address')
 
     @staticmethod
     def get_all_artwork(item, server):
@@ -596,10 +561,7 @@ class DownloadUtils:
             return token
 
         settings = xbmcaddon.Addon()
-        port = settings.getSetting("port")
-        host = settings.getSetting("ipaddress")
-        if host is None or host == "" or port is None or port == "":
-            return ""
+        server_address = settings.getSetting("server_address")
 
         url = "{server}/Users/AuthenticateByName?format=json"
 

--- a/resources/lib/server_detect.py
+++ b/resources/lib/server_detect.py
@@ -246,30 +246,20 @@ def check_server(force=False, change_user=False, notify=False):
                 else:
                     xbmc.executebuiltin("ActivateWindow(Home)")
                     return
+              
+                public_lookup_url = "%s/Users/Public?format=json" % (server_url)
 
-                url_bits = urlparse(server_url)
-                server_address = url_bits.hostname
-                server_port = str(url_bits.port)
-                server_protocol = url_bits.scheme
-                user_name = url_bits.username
-                user_password = url_bits.password
-
-                if user_name and user_password:
-                    temp_url = "%s://%s:%s@%s:%s/Users/Public?format=json" % (server_protocol, user_name, user_password, server_address, server_port)
-                else:
-                    temp_url = "%s://%s:%s/Users/Public?format=json" % (server_protocol, server_address, server_port)
-
-                log.debug("Testing_Url: {0}", temp_url)
+                log.debug("Testing_Url: {0}", public_lookup_url)
                 progress = xbmcgui.DialogProgress()
                 progress.create(__addon_name__ + " : " + string_load(30376))
                 progress.update(0, string_load(30377))
-                json_data = du.download_url(temp_url, authenticate=False)
+                json_data = du.download_url(public_lookup_url, authenticate=False)
                 progress.close()
 
                 result = json.loads(json_data)
                 if result is not None:
                     xbmcgui.Dialog().ok(__addon_name__ + " : " + string_load(30167),
-                                        "%s://%s:%s/" % (server_protocol, server_address, server_port))
+                                        server_url)
                     break
                 else:
                     return_index = xbmcgui.Dialog().yesno(__addon_name__ + " : " + string_load(30135),
@@ -280,29 +270,7 @@ def check_server(force=False, change_user=False, notify=False):
                         return
 
         log.debug("Selected server: {0}", server_url)
-
-        # parse the url
-        url_bits = urlparse(server_url)
-        server_address = url_bits.hostname
-        server_port = str(url_bits.port)
-        server_protocol = url_bits.scheme
-        user_name = url_bits.username
-        user_password = url_bits.password
-        log.debug("Detected server info {0} - {1} - {2}", server_protocol, server_address, server_port)
-
-        # save the server info
-        settings.setSetting("port", server_port)
-
-        if user_name and user_password:
-            server_address = "%s:%s@%s" % (url_bits.username, url_bits.password, server_address)
-
-        settings.setSetting("ipaddress", server_address)
-
-        if server_protocol == "https":
-            settings.setSetting("protocol", "1")
-        else:
-            settings.setSetting("protocol", "0")
-
+        settings.setSetting("server_address", server_url)
         something_changed = True
 
     # do we need to change the user

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,9 +4,10 @@
 
 		<setting label="30388" type="lsep"/>
 		<setting label="30011" type="action" action="RunScript(plugin.video.jellycon,0,?mode=DETECT_SERVER_USER)" option="close"/>
-		<setting id="protocol" type="select" label="30390" lvalues="30391|30392" default="0" />
-		<setting id="ipaddress" type="text" label="30000" default="&lt;none&gt;" visible="true" enable="true" />
-		<setting id="port" type="text" label="30001" default="8096" visible="true" enable="true" />
+		<setting id="ipaddress" type="text" label="30000" default="" visible="false" enable="false" />
+		<setting id="protocol" type="select" label="30390" lvalues="30391|30392" default="0" visible="false"/>			
+		<setting id="port" type="text" label="30001" default="8096" visible="false" enable="false" />
+		<setting id="server_address" type="text" label="30000" default="" visible="true" enable="true" />
 		<setting id="verify_cert" type="bool" label="30003" default="false" visible="true" enable="true" />
 
 		<setting label="30389" type="lsep"/>


### PR DESCRIPTION
Have put some migration code in for backwards comparability testing which appears to be doing okay. This fix will now default to using http and https default port as well as allow for baseurls to work properly