### PR TITLE
Fix websocket_url (fixes playing transcoded streams)

### DIFF
--- a/resources/lib/websocket_client.py
+++ b/resources/lib/websocket_client.py
@@ -254,7 +254,7 @@ class WebSocketClient(threading.Thread):
         else:
             server = server.replace('http', "ws")
 
-        websocket_url = "%s/websocket?api_key=%s&deviceId=%s" % (server, token, self.device_id)
+        websocket_url = "%s/socket?api_key=%s&deviceId=%s" % (server, token, self.device_id)
         log.debug("websocket url: {0}".format(websocket_url))
 
         self._client = websocket.WebSocketApp(websocket_url,


### PR DESCRIPTION
Jellycon still had the old endpoint at `/websocket` configured which got moved to `/socket`.
This changes the endpoint to the current upstream and therefore fixes playback of transcoded streams among other things involving the socket.