### PR TITLE
Stop doing string manipulations on translations

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -219,7 +219,7 @@ msgid "Include people"
 msgstr ""
 
 msgctxt "#30200"
-msgid "URL error: %s"
+msgid "URL error"
 msgstr ""
 
 msgctxt "#30201"
@@ -555,11 +555,11 @@ msgid "Cached Jellyfin images : "
 msgstr ""
 
 msgctxt "#30305"
-msgid "Not Found: %s"
+msgid "Not Found"
 msgstr ""
 
 msgctxt "#30306"
-msgid "Playback starting: %s"
+msgid "Playback starting"
 msgstr ""
 
 msgctxt "#30307"
@@ -683,7 +683,7 @@ msgid "Changes Require Kodi Restart"
 msgstr ""
 
 msgctxt "#30344"
-msgid "Number of images removed from cache : %s"
+msgid "Number of images removed from cache"
 msgstr ""
 
 msgctxt "#30345"
@@ -815,7 +815,7 @@ msgid "Sending request"
 msgstr ""
 
 msgctxt "#30375"
-msgid "Receiving data packet: %s"
+msgid "Receiving data packet"
 msgstr ""
 
 msgctxt "#30376"
@@ -891,7 +891,7 @@ msgid "Clear Cache Result"
 msgstr ""
 
 msgctxt "#30394"
-msgid "%s cache files deleted"
+msgid "Cache files deleted"
 msgstr ""
 
 msgctxt "#30395"

--- a/resources/lib/cache_images.py
+++ b/resources/lib/cache_images.py
@@ -107,7 +107,7 @@ class CacheArtwork(threading.Thread):
         progress.update(100, string_load(30125))
         progress.close()
 
-        xbmcgui.Dialog().ok(string_load(30281), string_load(30344) % delete_count)
+        xbmcgui.Dialog().ok(string_load(30281), '{}: {}'.format(string_load(30344), delete_count))
 
     def cache_artwork_interactive(self):
         log.debug("cache_artwork_interactive")

--- a/resources/lib/datamanager.py
+++ b/resources/lib/datamanager.py
@@ -274,6 +274,7 @@ def clear_cached_server_data():
             xbmcvfs.delete(os.path.join(addon_dir, filename))
             del_count += 1
 
+    log.debug('Deleted {} files'.format(del_count))
     msg = string_load(30394)
     xbmcgui.Dialog().ok(string_load(30393), msg)
 

--- a/resources/lib/datamanager.py
+++ b/resources/lib/datamanager.py
@@ -274,7 +274,7 @@ def clear_cached_server_data():
             xbmcvfs.delete(os.path.join(addon_dir, filename))
             del_count += 1
 
-    msg = string_load(30394) % del_count
+    msg = string_load(30394)
     xbmcgui.Dialog().ok(string_load(30393), msg)
 
 

--- a/resources/lib/downloadutils.py
+++ b/resources/lib/downloadutils.py
@@ -726,7 +726,7 @@ class DownloadUtils:
                 log.error("HTTP response error for {0}: {1} {2}".format(url, data.status_code, data.content))
                 if suppress is False:
                     xbmcgui.Dialog().notification(string_load(30316),
-                                                  string_load(30200) % str(data.content),
+                                                  '{}: {}'.format(string_load(30200), data.content),
                                                   icon="special://home/addons/plugin.video.jellycon/icon.png")
             try:
                 result = data.json()

--- a/resources/lib/server_detect.py
+++ b/resources/lib/server_detect.py
@@ -152,7 +152,7 @@ def get_server_details():
         while True:
             try:
                 server_count += 1
-                progress.update(server_count * 10, string_load(30375) % server_count)
+                progress.update(server_count * 10, '{}: {}'.format(string_load(30375), server_count))
                 xbmc.sleep(1000)
                 data, addr = sock.recvfrom(1024)
                 servers.append(json.loads(data))

--- a/resources/lib/trakttokodi.py
+++ b/resources/lib/trakttokodi.py
@@ -20,11 +20,11 @@ icon = xbmc.translatePath('special://home/addons/plugin.video.jellycon/icon.png'
 
 
 def not_found(content_string):
-    xbmcgui.Dialog().notification('JellyCon', string_load(30305) % content_string, icon=icon, sound=False)
+    xbmcgui.Dialog().notification('JellyCon', '{}: {}'.format(string_load(30305), content_string), icon=icon, sound=False)
 
 
 def playback_starting(content_string):
-    xbmcgui.Dialog().notification('JellyCon', string_load(30306) % content_string, icon=icon, sound=False)
+    xbmcgui.Dialog().notification('JellyCon', '{}: {}'.format(string_load(30306), content_string), icon=icon, sound=False)
 
 
 def search(item_type, query):


### PR DESCRIPTION
Some existing translations contain `%s` and are then replaced in the string when displayed to the user.  This is both ugly and a bad practice if/when we get localization set up, because that won't translate to other languages well.